### PR TITLE
Current nuget package is breaking; fixed to require specific version

### DIFF
--- a/Caliburn.Metro/Caliburn.Metro.nuspec
+++ b/Caliburn.Metro/Caliburn.Metro.nuspec
@@ -12,7 +12,7 @@
         <tags>Wpf Caliburn.Micro MahApps.Metro Mvvm MetroUI WindowManager</tags>
         <dependencies>
             <dependency id="Caliburn.Micro" version="[1.3.1]" />
-            <dependency id="MahApps.Metro" version="0.10.0.0" />
+            <dependency id="MahApps.Metro" version="[0.10.0.0]" />
             <dependency id="MahApps.Metro.Resources" version="0.1.0.1" />
         </dependencies>
     </metadata>


### PR DESCRIPTION
MahApps.Metro > 0.10.0.0 (ex, current latest 0.10.1.21) changed the assembly versions from 0.9.0 to 0.10.0, so references in Caliburn.Metro are no longer valid.
